### PR TITLE
🚸 Fix lookup duplicate handling for keep="first"/"last" return types

### DIFF
--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -61,12 +61,19 @@ def test_lookup_multiple_records():
 
     lookup = Lookup(df=df, field="name", keep="first").lookup()
     assert lookup.experiment.value == "value1"
+    assert type(lookup.experiment).__name__ == "MyTuple"
 
     lookup = Lookup(df=df, field="name", keep="last").lookup()
     assert lookup.experiment.value == "value2"
+    assert type(lookup.experiment).__name__ == "MyTuple"
 
     lookup = Lookup(df=df, field="name", keep=False).lookup()
     assert len(lookup.experiment) == 2
+    assert type(lookup.experiment).__name__ == "_ListValueWrapper"
+
+    lookup = Lookup(df=df, field="name", keep="first").lookup(return_field="value")
+    assert lookup.experiment == "value1"
+    assert type(lookup.experiment) is str
 
 
 def test_lookup_keyword_field():


### PR DESCRIPTION
Resolves: https://github.com/laminlabs/lamindb/issues/3562

- Update `.lookup(`) duplicate handling so `keep="first"` and `keep="last"` return the selected element directly (instead of `_ListValueWrapper`).
- Preserve `_ListValueWrapper` behavior for keep=False so full duplicate lists are still available.

Before | After
--- | ---
<img width="550" height="128" alt="image" src="https://github.com/user-attachments/assets/ddaeb611-3b02-492b-a0ed-d0ea9ec9e388" /> | <img width="569" height="226" alt="image" src="https://github.com/user-attachments/assets/7741b292-b2c8-4bb6-b61a-6ec824c69025" />
